### PR TITLE
Collective dream - reset sleep counter

### DIFF
--- a/DreamBrickSpawnCommand/dreambrickspawncommand/src/main/java/dev/xaiter/spigot/dreambrickspawncommand/App.java
+++ b/DreamBrickSpawnCommand/dreambrickspawncommand/src/main/java/dev/xaiter/spigot/dreambrickspawncommand/App.java
@@ -21,6 +21,7 @@ import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scoreboard.Objective;
 import org.bukkit.scoreboard.Score;
+import org.bukkit.Statistic;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.TextComponent;
 
@@ -89,6 +90,7 @@ public class App extends JavaPlugin implements Listener, CommandExecutor {
             for(Player p : onlinePlayers) {
                 if(IsPlayerValidSleepTarget(p)) {
                     WakeUpAndTeleportPlayer(p, s);
+                    ResetTimeSinceRest(p);
                     MessagePlayer(p, MSG_COLLECTIVE_DREAM, ChatColor.LIGHT_PURPLE);
                 }
             }
@@ -96,6 +98,10 @@ public class App extends JavaPlugin implements Listener, CommandExecutor {
             // If we don't cancel, the player who gets into bed last won't be TP'd.  :(
             e.setCancelled(true);
         }
+    }
+
+    private void ResetTimeSinceRest(Player p) {
+        p.setStatistic(Statistic.TIME_SINCE_REST, 0);
     }
 
     @EventHandler


### PR DESCRIPTION
- So a player is able to prevent phantoms from spawning
  even when he is teleported to spawn because (s)he is
  the only relevant sleeper currently.

@see: https://github.com/Xaiter/DreamBrickPlugins/issues/4